### PR TITLE
feat: Make HF_TOKEN optional and Move cache_dir to options

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "EasyControlLoadFlux": "Load EasyControl Flux Model Test",
+    "EasyControlLoadFlux": "Load EasyControl Flux Model",
     "EasyControlLoadLora": "Load EasyControl Lora",
     "EasyControlLoadMultiLora": "Load Multiple EasyControl Loras",
     "EasyControlGenerate": "EasyControl Generate",

--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "EasyControlLoadFlux": "Load EasyControl Flux Model",
+    "EasyControlLoadFlux": "Load EasyControl Flux Model Test",
     "EasyControlLoadLora": "Load EasyControl Lora",
     "EasyControlLoadMultiLora": "Load Multiple EasyControl Loras",
     "EasyControlGenerate": "EasyControl Generate",

--- a/nodes/comfy_nodes.py
+++ b/nodes/comfy_nodes.py
@@ -26,10 +26,11 @@ class EasyControlLoadFlux:
     @classmethod
     def INPUT_TYPES(cls):
         return {
-            "required": {
-                "hf_token": ("STRING", {"default": "", "multiline": True}),
-            },
-            "optional": {"load_8bit": ("BOOLEAN", {"default": True}), "cpu_offload": ("BOOLEAN", {"default": True})}
+            "optional": {
+                "load_8bit": ("BOOLEAN", {"default": True}),
+                "cpu_offload": ("BOOLEAN", {"default": True}),
+                "hf_token": ("STRING", {"default": "", "multiline": True})
+            }
         }
     
     RETURN_TYPES = ("EASYCONTROL_PIPE", "EASYCONTROL_TRANSFORMER")
@@ -37,7 +38,9 @@ class EasyControlLoadFlux:
     CATEGORY = "EasyControl"
 
     def load_model(self, load_8bit, cpu_offload, hf_token=None):
-        login(token=hf_token)
+        if hf_token is not None:
+            login(token=hf_token)
+
         base_path = "black-forest-labs/FLUX.1-dev"
         device = "cuda" if torch.cuda.is_available() else "cpu"
         cache_dir = folder_paths.get_folder_paths("diffusers")[0]

--- a/nodes/comfy_nodes.py
+++ b/nodes/comfy_nodes.py
@@ -29,7 +29,7 @@ class EasyControlLoadFlux:
             "optional": {
                 "load_8bit": ("BOOLEAN", {"default": True}),
                 "cpu_offload": ("BOOLEAN", {"default": True}),
-                "hf_token": ("STRING", {"default": "", "multiline": True})
+                "hf_token": ("STRING", {"default": None, "multiline": True})
             }
         }
     

--- a/nodes/comfy_nodes.py
+++ b/nodes/comfy_nodes.py
@@ -29,29 +29,29 @@ class EasyControlLoadFlux:
             "optional": {
                 "load_8bit": ("BOOLEAN", {"default": True}),
                 "cpu_offload": ("BOOLEAN", {"default": True}),
-                "hf_token": ("STRING", {"default": None, "multiline": True})
+                "hf_token": ("STRING", {"default": "", "multiline": True}),
+                "cache_dir": ("STRING", {"default": folder_paths.get_folder_paths("diffusers")[0]}),
             }
         }
-    
+
     RETURN_TYPES = ("EASYCONTROL_PIPE", "EASYCONTROL_TRANSFORMER")
     FUNCTION = "load_model"
     CATEGORY = "EasyControl"
 
-    def load_model(self, load_8bit, cpu_offload, hf_token=None):
-        if hf_token is not None:
+    def load_model(self, load_8bit, cpu_offload, hf_token, cache_dir):
+        if hf_token is not "":
             login(token=hf_token)
 
         base_path = "black-forest-labs/FLUX.1-dev"
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        cache_dir = folder_paths.get_folder_paths("diffusers")[0]
         print(cache_dir)
         if load_8bit:
-            quant_config_t5 = TransformersBitsAndBytesConfig(load_in_8bit=True,)
-            quant_config = DiffusersBitsAndBytesConfig(load_in_8bit=True,)
+            quant_config_t5 = TransformersBitsAndBytesConfig(load_in_8bit=True, )
+            quant_config = DiffusersBitsAndBytesConfig(load_in_8bit=True, )
         else:
             quant_config_t5 = None
             quant_config = None
-            
+
         text_encoder_2 = T5EncoderModel.from_pretrained(
             base_path,
             subfolder="text_encoder_2",
@@ -60,35 +60,37 @@ class EasyControlLoadFlux:
             cache_dir=cache_dir,
         )
         transformer = FluxTransformer2DModel.from_pretrained(
-            base_path, 
+            base_path,
             subfolder="transformer",
-            torch_dtype=torch.bfloat16, 
+            torch_dtype=torch.bfloat16,
             device=device,
             cache_dir=cache_dir,
             quantization_config=quant_config,
         )
-        
-        pipe = FluxPipeline.from_pretrained(base_path, transformer=transformer, text_encoder_2=text_encoder_2, torch_dtype=torch.bfloat16, device=device, cache_dir=cache_dir)
-        
+
+        pipe = FluxPipeline.from_pretrained(base_path, transformer=transformer, text_encoder_2=text_encoder_2,
+                                            torch_dtype=torch.bfloat16, device=device, cache_dir=cache_dir)
+
         if cpu_offload:
             pipe.enable_sequential_cpu_offload()
         else:
             pipe.to(device)
-        
+
         return (pipe, transformer)
+
 
 class EasyControlLoadLora:
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "transformer": ("EASYCONTROL_TRANSFORMER", ),
-                "lora_name": (folder_paths.get_filename_list("loras"), ),
+                "transformer": ("EASYCONTROL_TRANSFORMER",),
+                "lora_name": (folder_paths.get_filename_list("loras"),),
                 "lora_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
                 "cond_size": ("INT", {"default": 512, "min": 256, "max": 1024, "step": 64}),
             },
         }
-    
+
     RETURN_TYPES = ("EASYCONTROL_TRANSFORMER",)
     FUNCTION = "load_lora"
     CATEGORY = "EasyControl"
@@ -97,7 +99,8 @@ class EasyControlLoadLora:
         lora_path = folder_paths.get_full_path("loras", lora_name)
         set_single_lora(transformer, lora_path, lora_weights=[lora_weight], cond_size=cond_size)
         return (transformer,)
-    
+
+
 # New Node: FLUX Style LoRA Loader
 class EasyControlLoadStyleLora:
     @classmethod
@@ -109,7 +112,7 @@ class EasyControlLoadStyleLora:
                 "lora_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
             }
         }
-    
+
     RETURN_TYPES = ("EASYCONTROL_PIPE",)
     FUNCTION = "load_lora"
     CATEGORY = "EasyControl"
@@ -117,10 +120,10 @@ class EasyControlLoadStyleLora:
     def load_lora(self, pipe, lora_name, lora_weight):
         # Get the full path of the LoRA file
         lora_path = folder_paths.get_full_path("loras", lora_name)
-        
+
         # Load LoRA weights
         print(f"Loading FLUX Style LoRA: {lora_name}, Weight: {lora_weight}")
-        
+
         weight_name = lora_name
 
         # handle offload
@@ -128,9 +131,9 @@ class EasyControlLoadStyleLora:
 
         # Load LoRA weights
         pipe.load_lora_weights(lora_path, weight_name=weight_name, device=device)
-        
+
         # Fuse LoRA
-        # pipe.fuse_lora(lora_weights=[lora_weight])        
+        # pipe.fuse_lora(lora_weights=[lora_weight])
         return (pipe,)
 
 
@@ -141,10 +144,11 @@ class EasyControlLoadStyleLoraFromCivitai:
             "required": {
                 "pipe": ("EASYCONTROL_PIPE",),
                 "lora_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
-                "civitai_model_id": ("STRING", {"default": "", "tooltip": "The ID of the model to download from CivitAI."}),
+                "civitai_model_id": ("STRING",
+                                     {"default": "", "tooltip": "The ID of the model to download from CivitAI."}),
             }
         }
-    
+
     RETURN_TYPES = ("EASYCONTROL_PIPE",)
     FUNCTION = "load_lora"
     CATEGORY = "EasyControl"
@@ -153,13 +157,13 @@ class EasyControlLoadStyleLoraFromCivitai:
         civitai_token_id = os.getenv("CIVITAI_TOKEN", "").strip()
         if not civitai_token_id:
             raise RuntimeError("CIVITAI_TOKEN environment variable is not set or empty.")
-        
+
         loras_dir = folder_paths.get_folder_paths("loras")[0]
-        
+
         # Generate temporary filename for downloaded LoRA
         lora_filename = f"tmp_{civitai_model_id or 'downloaded_lora'}.safetensors"
         lora_path = os.path.join(loras_dir, lora_filename)
-        
+
         try:
             file_exists = os.path.exists(lora_path)
             if not file_exists:
@@ -169,14 +173,14 @@ class EasyControlLoadStyleLoraFromCivitai:
 
             # Load LoRA weights
             print(f"Loading FLUX Style LoRA: {lora_filename}, Weight: {lora_weight}")
-            
+
             device = next(pipe.transformer.parameters()).device
             pipe.load_lora_weights(lora_path, weight_name=lora_filename, device=device)
-            
+
             return (pipe,)
         except Exception as e:
             raise RuntimeError(f"Failed to load or download LoRA: {str(e)}")
-    
+
     def download_from_civitai(self, model_id, token_id, lora_path):
         print("Downloading LoRA from CivitAI")
         print(f"\tModel ID: {model_id}")
@@ -190,15 +194,15 @@ class EasyControlLoadMultiLora:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "transformer": ("EASYCONTROL_TRANSFORMER", ),
-                "lora_name1": (folder_paths.get_filename_list("loras"), ),
+                "transformer": ("EASYCONTROL_TRANSFORMER",),
+                "lora_name1": (folder_paths.get_filename_list("loras"),),
                 "lora_weight1": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
-                "lora_name2": (folder_paths.get_filename_list("loras"), ),
+                "lora_name2": (folder_paths.get_filename_list("loras"),),
                 "lora_weight2": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
                 "cond_size": ("INT", {"default": 512, "min": 256, "max": 1024, "step": 64}),
             },
         }
-    
+
     RETURN_TYPES = ("EASYCONTROL_TRANSFORMER",)
     FUNCTION = "load_multi_lora"
     CATEGORY = "EasyControl"
@@ -206,22 +210,23 @@ class EasyControlLoadMultiLora:
     def load_multi_lora(self, transformer, lora_name1, lora_weight1, lora_name2, lora_weight2, cond_size):
         lora_path1 = folder_paths.get_full_path("loras", lora_name1)
         lora_path2 = folder_paths.get_full_path("loras", lora_name2)
-        
+
         set_multi_lora(
-            transformer, 
-            [lora_path1, lora_path2], 
-            lora_weights=[[lora_weight1], [lora_weight2]], 
+            transformer,
+            [lora_path1, lora_path2],
+            lora_weights=[[lora_weight1], [lora_weight2]],
             cond_size=cond_size
         )
         return (transformer,)
+
 
 class EasyControlGenerate:
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "pipe": ("EASYCONTROL_PIPE", ),
-                "transformer": ("EASYCONTROL_TRANSFORMER", ),
+                "pipe": ("EASYCONTROL_PIPE",),
+                "transformer": ("EASYCONTROL_TRANSFORMER",),
                 "prompt": ("STRING", {"multiline": True}),
                 "prompt_2": ("STRING", {"multiline": True, "default": ""}),
                 "height": ("INT", {"default": 768, "min": 256, "max": 2048, "step": 64}),
@@ -234,27 +239,27 @@ class EasyControlGenerate:
                 "zero_steps": ("INT", {"default": 1, "min": 0, "max": 100}),
             },
             "optional": {
-                "spatial_image": ("IMAGE", ),
-                "subject_image": ("IMAGE", ),
+                "spatial_image": ("IMAGE",),
+                "subject_image": ("IMAGE",),
             }
         }
-    
+
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "generate"
     CATEGORY = "EasyControl"
 
-    def generate(self, pipe, transformer, prompt, prompt_2, height, width, guidance_scale, 
-                num_inference_steps, seed, cond_size, use_zero_init, zero_steps, spatial_image=None, subject_image=None):
+    def generate(self, pipe, transformer, prompt, prompt_2, height, width, guidance_scale,
+                 num_inference_steps, seed, cond_size, use_zero_init, zero_steps, spatial_image=None,
+                 subject_image=None):
         # Clear cache before generation
         for name, attn_processor in transformer.attn_processors.items():
             attn_processor.bank_kv.clear()
-        
-        
+
         # Prepare spatial images
         spatial_images = []
         print("spatial_image")
         print(spatial_image)
-        
+
         if spatial_image is not None:
             # Convert from tensor or numpy to PIL
             if isinstance(spatial_image, torch.Tensor):
@@ -271,7 +276,7 @@ class EasyControlGenerate:
             elif isinstance(spatial_image, np.ndarray):
                 spatial_image_pil = Image.fromarray((spatial_image * 255).astype(np.uint8))
                 spatial_images.append(spatial_image_pil)
-        
+
         # Prepare subject images
         subject_images = []
         if subject_image is not None:
@@ -290,7 +295,7 @@ class EasyControlGenerate:
             elif isinstance(subject_image, np.ndarray):
                 subject_image_pil = Image.fromarray((subject_image * 255).astype(np.uint8))
                 subject_images.append(subject_image_pil)
-        
+
         # Set prompt_2 to None if empty
         if not prompt_2:
             prompt_2 = None
@@ -300,7 +305,7 @@ class EasyControlGenerate:
 
         print("subject_images")
         print(subject_images)
-        
+
         # Generate image
         output = pipe(
             prompt=prompt,
@@ -317,23 +322,23 @@ class EasyControlGenerate:
             use_zero_init=use_zero_init,
             zero_steps=int(zero_steps)
         )
-        
+
         # Convert PIL image to numpy array, then to torch.Tensor
         if isinstance(output, FluxPipelineOutput):
             image = np.array(output.images[0]) / 255.0
         else:
             image = np.array(output[0]) / 255.0
-        
+
         # Convert numpy array to torch.Tensor
         image = torch.from_numpy(image).float()
-        
+
         # Add batch dimension to make it [batch, height, width, channels]
         if image.dim() == 3:  # [height, width, channels]
             image = image.unsqueeze(0)  # Add batch dimension to make it [1, height, width, channels]
-        
+
         # Clear cache after generation
         for name, attn_processor in transformer.attn_processors.items():
             attn_processor.bank_kv.clear()
-        
+
         return (image,)
 


### PR DESCRIPTION
In this Pull Request I'm making HF_TOKEN optional - leaving it empty will proceed with an attempt to use the downloaded weights, allowing it work offline.
In case someone already has everything set up elsewhere, cache_dir was turned to optional param with default value equals to it currently is.